### PR TITLE
Correction compilation recettes inclusion

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   avr:
     image: avr_build:0.0.1
+    user: ${UID}:${GID}
     container_name: avr
     volumes:
       - ~/workspace/bare-duino/:/usr/app/
@@ -25,6 +26,15 @@ services:
       - -c
       - | 
         make clean
+
+  cleanall:
+    extends: avr
+    container_name: avr_cleanall
+    command:
+      - /bin/sh
+      - -c
+      - | 
+        make distclean
 
   install:
     extends: avr

--- a/tools/module.mk
+++ b/tools/module.mk
@@ -39,7 +39,7 @@ C_CPLUS_FLAGS += -Os -pedantic
 C_CPLUS_FLAGS += -Wswitch-default -Wswitch-enum
 C_CPLUS_FLAGS += -Wunreachable-code -Wconversion -Wcast-qual
 C_CPLUS_FLAGS += -mmcu=atmega328p -DF_CPU=16000000UL
-C_CPLUS_FLAGS += -DARDUINO=10819 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -MMD
+C_CPLUS_FLAGS += -DARDUINO=10819 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR
 C_CPLUS_FLAGS += $(INTEG_LOG_LEVEL)
 
 C_FLAGS		+= $(C_CPLUS_FLAGS) -Wstrict-prototypes -std=c99


### PR DESCRIPTION
La génération des fichiers de dépendances n'était pas effectuée correctement à cause d'une mauvaise configuration des flags de compilation.