### PR TITLE
Feature/docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 RUN apk add --update alpine-sdk libc6-compat
 
-COPY avr8-gnu-toolchain-3.7.0.1796-linux.any.x86_64.tar.gz /opt/avr8-gnu-toolchain-3.7.0.1796-linux.any.x86_64.tar.gz
+ADD https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/avr8-gnu-toolchain-3.7.0.1796-linux.any.x86_64.tar.gz /opt/avr8-gnu-toolchain-3.7.0.1796-linux.any.x86_64.tar.gz
 
 RUN cd /opt/ && \
     tar -xf avr8-gnu-toolchain-3.7.0.1796-linux.any.x86_64.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ docker compose up build
 
 ### Add some extra configuration to avoid doing it all the time
 
-To avoid exporting the variables each time you open a new terminal, you can add these lines to your .bashrc file :
+To avoid exporting the variables each time you open a new terminal, you can add these lines to your `.bashrc` file :
 
 ```shell
 # No need to export them manually now ! 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,65 @@ foo@bar:~/bare-duino$ make
 ## About
 
 We will try to implement basic features like a serial console or drivers for specific devices like a RF transmitter/receiver or bluetooth components.
+
+## Using Docker to build
+
+You can build a docker image that will help you build the binaries.
+
+### Install docker, the proper way
+
+You can find the official instructions [here](https://docs.docker.com/engine/install/ "Official instructions for Docker Engine"). You need the docker compose and the docker buildx plugins so install them as well if it is not already done.
+
+```console
+sudo apt update
+sudo apt install docker-compose-plugin docker-buildx-plugin
+```
+
+Do not forget to add your account to the docker group so that you can run the docker CLI without sudo !
+```console
+# You will need to logout and login again for the change to be applied
+sudo usermod -aG docker <your_username>
+```
+
+### Build the image and tag it
+
+For the compilation to work, you need to build the image used in the docker-compose.yaml and then tag it with the proper name.
+
+```console
+# Move to the repo folder
+cd /path/to/bare-duino
+
+# Build the image and tag it in the same process
+docker buildx build . --tag avr_build:0.0.1
+```
+
+### Compile your binary with your image
+
+Now that your image is ready, you can use it to compile your binary.
+
+```console
+# Export the following variables so that your build is owned by your account
+export USERID=$(id -u)
+export GROUPID=$(id -g)
+
+docker compose up clean
+docker compose up build
+```
+
+### Add some extra configuration to avoid doing it all the time
+
+To avoid exporting the variables each time you open a new terminal, you can add these lines to your .bashrc file :
+
+```shell
+# No need to export them manually now ! 
+export USERID=$(id -u)
+export GROUPID=$(id -g)
+
+# Now the command to build is simply "dcu build"
+alias dcu='docker compose up'
+```
+
+You can build custom targets in the container by calling 
+```console
+CUSTOM_CMD=<target> dcu custom
+```

--- a/README.md
+++ b/README.md
@@ -13,18 +13,22 @@ This "tutorial" is for Linux users but it also works for people who use the Wind
     * Copy the archive in your /opt folder
     * Unzip it with tar :
 
-```console
-foo@bar:~$ sudo cp Downloads/avr-gcc-8.5.0-1-x64-linux.tar.xz /opt/
-foo@bar:~$ cd /opt
-foo@bar:/opt$ sudo tar -xz avr-gcc-8.5.0-1-x64-linux.tar.xz
+```shell
+# Download the archive and copy it in the /opt folder
+sudo cp Downloads/avr-gcc-8.5.0-1-x64-linux.tar.xz /opt/
+cd /opt
+
+# Untar it directly at the root
+sudo tar -xz avr-gcc-8.5.0-1-x64-linux.tar.xz
 ```
 
 * Go into the folder and run the script **permissions.sh** with sudo rights
 
-```console
-foo@bar:/opt$ cd /avr-gcc-8.5.0-1-x64-linux
-foo@bar:/opt/avr-gcc-8.5.0-1-x64-linux$ sudo chmod +x permissions.sh
-foo@bar:/opt/avr-gcc-8.5.0-1-x64-linux$ sudo ./permissions.sh
+```shell
+cd ./avr-gcc-8.5.0-1-x64-linux
+
+sudo chmod +x permissions.sh
+sudo ./permissions.sh
 ```
 
 * That's it ! Your toolchain is ready !
@@ -36,9 +40,12 @@ foo@bar:/opt/avr-gcc-8.5.0-1-x64-linux$ sudo ./permissions.sh
     * Clone this repository into your workspace
     * Run make (parallel compilation not supported at the moment)
 
-```console
-foo@bar:~/bare-duino$ git clone https://github.com/Contarkos/bare-duino.git
-foo@bar:~/bare-duino$ make
+```shell
+# In your own workspace
+git clone https://github.com/Contarkos/bare-duino.git
+
+# This will build everything you need in the folder env/MAIN/bin
+make
 ```
 
 * Upload the binary
@@ -59,13 +66,13 @@ You can build a docker image that will help you build the binaries.
 
 You can find the official instructions [here](https://docs.docker.com/engine/install/ "Official instructions for Docker Engine"). You need the docker compose and the docker buildx plugins so install them as well if it is not already done.
 
-```console
+```shell
 sudo apt update
 sudo apt install docker-compose-plugin docker-buildx-plugin
 ```
 
 Do not forget to add your account to the docker group so that you can run the docker CLI without sudo !
-```console
+```shell
 # You will need to logout and login again for the change to be applied
 sudo usermod -aG docker <your_username>
 ```
@@ -74,7 +81,7 @@ sudo usermod -aG docker <your_username>
 
 For the compilation to work, you need to build the image used in the docker-compose.yaml and then tag it with the proper name.
 
-```console
+```shell
 # Move to the repo folder
 cd /path/to/bare-duino
 
@@ -86,7 +93,7 @@ docker buildx build . --tag avr_build:0.0.1
 
 Now that your image is ready, you can use it to compile your binary.
 
-```console
+```shell
 # Export the following variables so that your build is owned by your account
 export USERID=$(id -u)
 export GROUPID=$(id -g)
@@ -109,6 +116,6 @@ alias dcu='docker compose up'
 ```
 
 You can build custom targets in the container by calling 
-```console
+```shell
 CUSTOM_CMD=<target> dcu custom
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 services:
   avr:
     image: avr_build:0.0.1
-    user: ${UID}:${GID}
+    user: ${USERID}:${GROUPID}
     container_name: avr
     volumes:
-      - ~/workspace/bare-duino/:/usr/app/
+      - ${PWD}:/usr/app/
     # Pour bash
     stdin_open: true
     tty: true
@@ -35,6 +35,15 @@ services:
       - -c
       - | 
         make distclean
+
+  custom:
+    extends: avr
+    container_name: avr_custom
+    command:
+      - /bin/sh
+      - -c
+      - | 
+        make ${CUSTOM_CMD}
 
   install:
     extends: avr


### PR DESCRIPTION
Il est possible voire même plus pratique d'installer docker et de créer une image servant à compiler le binaire que d'installer toute la chaine dans le système. 

Ces modifications indiquent comment procéder pour obtenir le même résultat de compilation sans avoir à copier des fichiers dans notre propre système.